### PR TITLE
Mehul/get by email

### DIFF
--- a/openapi/crm/objects/contacts/basic.yaml
+++ b/openapi/crm/objects/contacts/basic.yaml
@@ -254,3 +254,56 @@ paths:
                   properties:
                     type: object
                     description: The updated contact properties.
+  /crm/v3/objects/contacts/search:
+    post:
+      summary: Search for contacts by email
+      description: |
+        Queries the HubSpot CRM for contacts based on the `email` property.
+        Returns contact details such as `firstname`, `lastname`, and `email`.
+      operationId: searchContactsByEmail
+      tags:
+        - Contacts
+      parameters:
+        - name: hapikey
+          in: query
+          description: HubSpot API key
+          required: true
+          schema:
+            type: string
+            example: "YOUR_API_KEY"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      propertyName:
+                        type: string
+                        example: "email"
+                      operator:
+                        type: string
+                        example: "EQ"
+                      value:
+                        type: string
+                        example: "example@example.com"
+                properties:
+                  type: array
+                  items:
+                    type: string
+                    example: ["firstname", "lastname", "email"]
+                limit:
+                  type: integer
+                  example: 1
+      responses:
+        "200":
+          description: Contact object details.
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/ContactsResponse"

--- a/tests/crm/objects/contacts/basic_test.go
+++ b/tests/crm/objects/contacts/basic_test.go
@@ -290,6 +290,18 @@ func TestSearchContactsByEmail(t *testing.T) {
 		t.Fatalf("API call failed: %v", err)
 	}
 
+	var result struct {
+		Total int `json:"total"`
+	}
+
+	if err := json.Unmarshal(response.Body, &result); err != nil {
+		t.Fatalf("Failed to parse response body: %v", err)
+	}
+
+	if result.Total == 0 {
+		t.Fatalf("Response contains no results")
+	}
+
 	if response.StatusCode() == 200 {
 		if response.JSON200 == nil || response.JSON200.Results == nil {
 			t.Fatalf("Response contains no results")

--- a/tests/crm/objects/contacts/basic_test.go
+++ b/tests/crm/objects/contacts/basic_test.go
@@ -241,3 +241,75 @@ func TestUpdateContact(t *testing.T) {
 		t.Fatalf("Test Failed with status code %d: %v", response.StatusCode(), response)
 	}
 }
+
+func TestSearchContactsByEmail(t *testing.T) {
+	// Fetch the access token from the environment
+	token := os.Getenv("HS_ACCESS_TOKEN")
+
+	if token == "" {
+		t.Skip("HS_ACCESS_TOKEN is not set. Skipping test.")
+	}
+
+	// Correctly initialize the struct with the proper syntax
+	config := configuration.Configuration{
+		AccessToken:            token,
+		BasePath:               BaseURL,
+		NumberOfAPICallRetries: 3,
+	}
+
+	hsClient := hubspot.NewClient(config)
+
+	// Initialize the client
+	hsClient.SetAccessToken(token)
+
+	// Make the API call
+
+	jsonInput := `{
+		"filters": [
+			{
+				"propertyName": "email",
+				"operator": "EQ",
+				"value": "johndoe5@example.com"
+			}
+		],
+		"limit": 1
+	}`
+	contactByEmailParam := contacts.SearchContactsByEmailParams{}
+
+	var body contacts.SearchContactsByEmailJSONRequestBody
+
+	if err := json.Unmarshal([]byte(jsonInput), &body); err != nil {
+		t.Fatalf("Error unmarshaling JSON: %v", err)
+		return
+	}
+
+	ct := hsClient.Crm().Contacts().Contacts
+
+	response, err := ct.SearchContactsByEmailWithResponse(context.Background(), &contactByEmailParam, body)
+	if err != nil {
+		t.Fatalf("API call failed: %v", err)
+	}
+
+	if response.StatusCode() == 200 {
+		if response.JSON200 == nil || response.JSON200.Results == nil {
+			t.Fatalf("Response contains no results")
+		}
+
+		for _, result := range *response.JSON200.Results {
+			t.Logf("%+v\n", result)
+			t.Log("-----")
+
+			// Assuming Properties is a map of key-value pairs
+			if result.Properties != nil {
+				for key, value := range *result.Properties {
+					t.Logf("Key: %s, Value: %+v\n", key, value)
+				}
+			} else {
+				t.Log("No properties found.")
+			}
+			t.Log("-----")
+		}
+	} else {
+		t.Fatalf("Test Failed with status code %d: %v", response.StatusCode(), response)
+	}
+}


### PR DESCRIPTION
**Added API to Retrieve Contact by Email**
Implemented a new API endpoint to fetch contact details based on the provided email address. This enhancement allows for streamlined querying of contact information using an email as a unique identifier.

**Key Changes**:

- Added functionality to retrieve contact data by email.
- Included necessary validations to ensure accurate and secure responses.
- Updated related documentation and test cases.